### PR TITLE
feat: added /slack response

### DIFF
--- a/src/controllers/cards.ts
+++ b/src/controllers/cards.ts
@@ -12,6 +12,7 @@ class CardController extends DefaultController {
   public initializeRoutes() {
     this.router.get(`${this.path}/:id`, this.getCardByID);
     this.router.get(`${this.path}`, this.drawThreeCards);
+    this.router.post(`${this.path}/slack`, this.drawThreeCardsSlack);
   }
 
   /**
@@ -50,6 +51,41 @@ class CardController extends DefaultController {
     };
     logger.info(`CardController.drawThreeCards: ${cards[0].name}, ${cards[1].name}, ${cards[2].name}`);
     response.status(200).send(cardResponse);
+  }
+
+  private drawThreeCardsSlack = (
+    request: express.Request,
+    response: express.Response
+  ) => {
+    const cardResponse = this.getSlackResponse();
+    const cards = newDeckDrawThree();
+    const slackResponse = {
+        blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `**Past:** ${cards[0].cardImages[0].url.tiny} ${cards[0].name},`
+          }
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `**Present:** ${cards[1].cardImages[0].url.tiny} ${cards[1].name},`
+          }
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `**Future:** ${cards[2].cardImages[0].url.tiny} ${cards[2].name},`
+          }
+        }
+      ]
+    };
+    logger.info(`CardController.drawThreeCardsSlack: ${cards[0].name}, ${cards[1].name}, ${cards[2].name}`);
+    response.status(200).send(slackResponse);
   }
 }
 

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -30,6 +30,13 @@ class DefaultController {
             }
         };
     }
+
+    public getSlackResponse() {
+        return {
+            response_type: "in_channel",
+            text: "",
+          };
+    }
 }
 
   export { DefaultController }


### PR DESCRIPTION
### Description of changes

* adds a `/cards/slack` endpoint that accepts HTTP POST intended for a slack command
* response is composed with slack message compliant language for rendering small images
* returns 3 cards. 

For additional information around slack messages in RESTful responses review 

- https://api.slack.com/interactivity/slash-commands#responding_to_a_command
- https://api.slack.com/messaging/composing

This specific PR is to push towards completing optional issue here: 
https://github.com/free-ignorance/soothsaying/issues/15